### PR TITLE
fix: remove duplicate with block in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,3 @@ jobs:
         with:
           files: artifacts.zip
           generate_release_notes: true
-        with:
-          files: artifacts.zip
-          generate_release_notes: true


### PR DESCRIPTION
Fixes YAML parsing error in release.yml that was causing immediate workflow failures